### PR TITLE
PERFFORJ-57: Mark TimingTestCase as abstract

### DIFF
--- a/src/test/java/org/perf4j/TimingTestCase.java
+++ b/src/test/java/org/perf4j/TimingTestCase.java
@@ -26,7 +26,7 @@ import java.io.PrintWriter;
 /**
  * Base test class just sets up some simple StopWatches and a dummy log of those stop watches.
  */
-public class TimingTestCase extends TestCase {
+public abstract class TimingTestCase extends TestCase {
     protected List<StopWatch> testStopWatches;
     protected String testLog;
 


### PR DESCRIPTION
Minor change to mark test base class as abstract as it contains only
setUp() and no tests, this helps IDEs/tools to exclude it from test runs.
