### PR TITLE
PERFFORJ-61 Allow AspectJ profiling with without adding @Profiled

### DIFF
--- a/src/main/java/org/perf4j/commonslog/aop/ScopedTimingAspect.java
+++ b/src/main/java/org/perf4j/commonslog/aop/ScopedTimingAspect.java
@@ -1,0 +1,43 @@
+/* Copyright (c) 2011 Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.commonslog.aop;
+
+import org.apache.commons.logging.LogFactory;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.perf4j.aop.AbstractTimingAspect;
+import org.perf4j.commonslog.CommonsLogStopWatch;
+
+/**
+ * 
+ * @author Brett Randall
+ * 
+ */
+
+@Aspect
+public abstract class ScopedTimingAspect extends AbstractTimingAspect {
+
+    @Override
+    @Pointcut("if(false")
+    public void useProfiled() {
+    }
+
+    protected CommonsLogStopWatch newStopWatch(String loggerName, String levelName) {
+        int levelInt = CommonsLogStopWatch.mapLevelName(levelName);
+        return new CommonsLogStopWatch(LogFactory.getLog(loggerName), levelInt, levelInt);
+    }
+    
+}

--- a/src/main/java/org/perf4j/commonslog/aop/TimingAspect.java
+++ b/src/main/java/org/perf4j/commonslog/aop/TimingAspect.java
@@ -15,10 +15,8 @@
  */
 package org.perf4j.commonslog.aop;
 
-import org.apache.commons.logging.LogFactory;
 import org.aspectj.lang.annotation.Aspect;
-import org.perf4j.aop.AbstractTimingAspect;
-import org.perf4j.commonslog.CommonsLogStopWatch;
+import org.aspectj.lang.annotation.Pointcut;
 
 /**
  * This TimingAspect implementation uses an Apache Commons Logging Log instance to persist StopWatch log messages.
@@ -26,9 +24,16 @@ import org.perf4j.commonslog.CommonsLogStopWatch;
  * @author Alex Devine
  */
 @Aspect
-public class TimingAspect extends AbstractTimingAspect {
-    protected CommonsLogStopWatch newStopWatch(String loggerName, String levelName) {
-        int levelInt = CommonsLogStopWatch.mapLevelName(levelName);
-        return new CommonsLogStopWatch(LogFactory.getLog(loggerName), levelInt, levelInt);
+public class TimingAspect extends ScopedTimingAspect {
+
+    @Override
+    @Pointcut("if(false)")
+    public void scope() {
     }
+
+    @Override
+    @Pointcut("if(true)")
+    public void useProfiled() {
+    }
+
 }

--- a/src/main/java/org/perf4j/javalog/aop/ScopedTimingAspect.java
+++ b/src/main/java/org/perf4j/javalog/aop/ScopedTimingAspect.java
@@ -1,0 +1,45 @@
+/* Copyright 2011 (c) Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.javalog.aop;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.perf4j.aop.AbstractTimingAspect;
+import org.perf4j.javalog.JavaLogStopWatch;
+
+/**
+ * 
+ * @author Brett Randall
+ * 
+ */
+
+@Aspect
+public abstract class ScopedTimingAspect extends AbstractTimingAspect {
+
+    @Override
+    @Pointcut("if(false)")
+    public void useProfiled() {
+    }
+
+    protected JavaLogStopWatch newStopWatch(String loggerName, String levelName) {
+        Level level = JavaLogStopWatch.mapLevelName(levelName);
+        return new JavaLogStopWatch(Logger.getLogger(loggerName), level, level);
+    }
+
+}

--- a/src/main/java/org/perf4j/javalog/aop/TimingAspect.java
+++ b/src/main/java/org/perf4j/javalog/aop/TimingAspect.java
@@ -16,11 +16,8 @@
 package org.perf4j.javalog.aop;
 
 import org.aspectj.lang.annotation.Aspect;
-import org.perf4j.aop.AbstractTimingAspect;
-import org.perf4j.javalog.JavaLogStopWatch;
+import org.aspectj.lang.annotation.Pointcut;
 
-import java.util.logging.Logger;
-import java.util.logging.Level;
 
 /**
  * This TimingAspect implementation uses java.util.logging to persist StopWatch log messages.
@@ -28,9 +25,16 @@ import java.util.logging.Level;
  * @author Alex Devine
  */
 @Aspect
-public class TimingAspect extends AbstractTimingAspect {
-    protected JavaLogStopWatch newStopWatch(String loggerName, String levelName) {
-        Level level = JavaLogStopWatch.mapLevelName(levelName);
-        return new JavaLogStopWatch(Logger.getLogger(loggerName), level, level);
+public class TimingAspect extends ScopedTimingAspect {
+
+    @Override
+    @Pointcut("if(false)")
+    public void scope() {
     }
+
+    @Override
+    @Pointcut("if(true)")
+    public void useProfiled() {
+    }
+
 }

--- a/src/main/java/org/perf4j/log4j/aop/ScopedTimingAspect.java
+++ b/src/main/java/org/perf4j/log4j/aop/ScopedTimingAspect.java
@@ -1,0 +1,45 @@
+/* Copyright 2011 (c) Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.log4j.aop;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.perf4j.aop.AbstractTimingAspect;
+import org.perf4j.log4j.Log4JStopWatch;
+
+/**
+ * 
+ * @author Brett Randall
+ * 
+ */
+@Aspect
+public abstract class ScopedTimingAspect extends AbstractTimingAspect {
+
+    @Override
+    @Pointcut("if(false)")
+    public void useProfiled() {
+        // TODO Auto-generated method stub
+
+    }
+
+    protected Log4JStopWatch newStopWatch(String loggerName, String levelName) {
+        Level level = Level.toLevel(levelName, Level.INFO);
+        return new Log4JStopWatch(Logger.getLogger(loggerName), level, level);
+    }
+
+}

--- a/src/main/java/org/perf4j/log4j/aop/TimingAspect.java
+++ b/src/main/java/org/perf4j/log4j/aop/TimingAspect.java
@@ -15,11 +15,8 @@
  */
 package org.perf4j.log4j.aop;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.aspectj.lang.annotation.Aspect;
-import org.perf4j.aop.AbstractTimingAspect;
-import org.perf4j.log4j.Log4JStopWatch;
+import org.aspectj.lang.annotation.Pointcut;
 
 /**
  * This TimingAspect implementation uses Log4j to persist StopWatch log messages.
@@ -27,9 +24,15 @@ import org.perf4j.log4j.Log4JStopWatch;
  * @author Alex Devine
  */
 @Aspect
-public class TimingAspect extends AbstractTimingAspect {
-    protected Log4JStopWatch newStopWatch(String loggerName, String levelName) {
-        Level level = Level.toLevel(levelName, Level.INFO);
-        return new Log4JStopWatch(Logger.getLogger(loggerName), level, level);
+public class TimingAspect extends ScopedTimingAspect {
+
+    @Override
+    @Pointcut("if(false)")
+    public void scope() {
+    }
+
+    @Override
+    @Pointcut("if(true)")
+    public void useProfiled() {
     }
 }

--- a/src/main/java/org/perf4j/slf4j/aop/ScopedTimingAspect.java
+++ b/src/main/java/org/perf4j/slf4j/aop/ScopedTimingAspect.java
@@ -1,0 +1,42 @@
+/* Copyright 2011 (c) Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.slf4j.aop;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.perf4j.aop.AbstractTimingAspect;
+import org.perf4j.slf4j.Slf4JStopWatch;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * @author Brett Randall
+ * 
+ */
+@Aspect
+public abstract class ScopedTimingAspect extends AbstractTimingAspect {
+
+    @Override
+    @Pointcut("if(false)")
+    public void useProfiled() {
+    }
+
+    protected Slf4JStopWatch newStopWatch(String loggerName, String levelName) {
+        int levelInt = Slf4JStopWatch.mapLevelName(levelName);
+        return new Slf4JStopWatch(LoggerFactory.getLogger(loggerName), levelInt, levelInt);
+    }
+
+}

--- a/src/main/java/org/perf4j/slf4j/aop/TimingAspect.java
+++ b/src/main/java/org/perf4j/slf4j/aop/TimingAspect.java
@@ -16,9 +16,7 @@
 package org.perf4j.slf4j.aop;
 
 import org.aspectj.lang.annotation.Aspect;
-import org.perf4j.aop.AbstractTimingAspect;
-import org.perf4j.slf4j.Slf4JStopWatch;
-import org.slf4j.LoggerFactory;
+import org.aspectj.lang.annotation.Pointcut;
 
 /**
  * This TimingAspect implementation uses a SLF4J Logger instance to persist StopWatch log messages.
@@ -26,9 +24,16 @@ import org.slf4j.LoggerFactory;
  * @author Alex Devine
  */
 @Aspect
-public class TimingAspect extends AbstractTimingAspect {
-    protected Slf4JStopWatch newStopWatch(String loggerName, String levelName) {
-        int levelInt = Slf4JStopWatch.mapLevelName(levelName);
-        return new Slf4JStopWatch(LoggerFactory.getLogger(loggerName), levelInt, levelInt);
+public class TimingAspect extends ScopedTimingAspect {
+
+    @Override
+    @Pointcut("if(false)")
+    public void scope() {
     }
+
+    @Override
+    @Pointcut("if(true)")
+    public void useProfiled() {
+    }
+
 }

--- a/src/test/java/org/perf4j/aop/AopTest.java
+++ b/src/test/java/org/perf4j/aop/AopTest.java
@@ -119,6 +119,16 @@ public class AopTest extends TestCase {
                    InMemoryTimingAspect.getLastLoggedString().indexOf("expressionTest_null]") >= 0);
         assertTrue("Expected message not found in " + InMemoryTimingAspect.getLastLoggedString(),
                    InMemoryTimingAspect.getLastLoggedString().indexOf("message[message: 5, exception: java.lang.Exception: failure]") >= 0);
+
+        // additionalScope, not @Profiled, see concrete aspect in aop.xml
+        profiledObject.simpleTestUnprofiled(50);
+        assertTrue("Expected tag not found in " + InMemoryTimingAspect.getLastLoggedString(),
+                InMemoryTimingAspect.getLastLoggedString().indexOf("tag[simpleTestUnprofiled]") >= 0);
+
+        // false assertion - this method should not be advised/logged, see aop.xml
+        profiledObject.simpleTestUnprofiledNotAdvised(50);
+        assertFalse("Expected tag not found in " + InMemoryTimingAspect.getLastLoggedString(),
+                InMemoryTimingAspect.getLastLoggedString().indexOf("tag[simpleTestUnprofiledNotAdvised]") >= 0);
     }
 
     public void testConcurrentCalls() throws Exception {

--- a/src/test/java/org/perf4j/aop/InMemoryTimingAspect.java
+++ b/src/test/java/org/perf4j/aop/InMemoryTimingAspect.java
@@ -16,30 +16,22 @@
 package org.perf4j.aop;
 
 import org.aspectj.lang.annotation.Aspect;
-import org.apache.log4j.Level;
-import org.perf4j.LoggingStopWatch;
+import org.aspectj.lang.annotation.Pointcut;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Collections;
 
 /**
  * This class is used by the AOP tests to check when the aspect was called
  */
 @Aspect
-public class InMemoryTimingAspect extends AbstractTimingAspect {
-    public static List<String> logStrings = Collections.synchronizedList(new ArrayList<String>());
+public class InMemoryTimingAspect extends ScopedInMemoryTimingAspect {
+    @Override
+    @Pointcut("if(true)")
+    public void useProfiled() {
+    }
 
-    protected LoggingStopWatch newStopWatch(final String loggerName, final String levelName) {
-        return new LoggingStopWatch() {
-            public boolean isLogging() {
-                return Level.toLevel(levelName).toInt() >= Level.INFO_INT;
-            }
-
-            protected void log(String stopWatchAsString, Throwable exception) {
-                InMemoryTimingAspect.logStrings.add(stopWatchAsString);
-            }
-        };
+    @Override
+    @Pointcut("if(false)")
+    public void scope() {
     }
 
     public static String getLastLoggedString() {

--- a/src/test/java/org/perf4j/aop/ProfiledObject.java
+++ b/src/test/java/org/perf4j/aop/ProfiledObject.java
@@ -111,6 +111,16 @@ public class ProfiledObject {
         return sleepTime;
     }
 
+    public long simpleTestUnprofiled(long sleepTime) throws Exception {
+	    Thread.sleep(sleepTime);
+        return sleepTime;
+	}
+
+    public long simpleTestUnprofiledNotAdvised(long sleepTime) throws Exception {
+	    Thread.sleep(sleepTime);
+        return sleepTime;
+	}
+
     //this method is called using JEXL in the @Profiled tags above
     public int getBeanProp() {
         return 5;

--- a/src/test/java/org/perf4j/aop/ScopedInMemoryTimingAspect.java
+++ b/src/test/java/org/perf4j/aop/ScopedInMemoryTimingAspect.java
@@ -1,0 +1,58 @@
+/* Copyright (c) 2011 Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.aop;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.log4j.Level;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.perf4j.LoggingStopWatch;
+
+/**
+ * 
+ * @author Brett Randall
+ * 
+ */
+@Aspect
+public abstract class ScopedInMemoryTimingAspect extends AbstractTimingAspect {
+
+    public static List<String> logStrings = Collections.synchronizedList(new ArrayList<String>());
+
+    @Override
+    @Pointcut
+    public abstract void scope();
+
+    @Override
+    @Pointcut("if(false)")
+    public void useProfiled() {
+    }
+
+    protected LoggingStopWatch newStopWatch(final String loggerName, final String levelName) {
+        return new LoggingStopWatch() {
+            public boolean isLogging() {
+                return Level.toLevel(levelName).toInt() >= Level.INFO_INT;
+            }
+    
+            protected void log(String stopWatchAsString, Throwable exception) {
+                InMemoryTimingAspect.logStrings.add(stopWatchAsString);
+            }
+        };
+    }
+
+}

--- a/src/test/java/org/perf4j/javalog/aop/AopTest.java
+++ b/src/test/java/org/perf4j/javalog/aop/AopTest.java
@@ -1,0 +1,53 @@
+/* Copyright (c) 2011 Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.javalog.aop;
+
+import java.util.logging.Logger;
+
+import org.perf4j.StopWatch;
+import org.perf4j.aop.ProfiledObject;
+
+import junit.framework.TestCase;
+
+/**
+ * 
+ * @author Brett Randall
+ * 
+ */
+public class AopTest extends TestCase {
+
+    public void testAspects() throws Exception {
+
+        final ListHandler listHandler = new ListHandler(); 
+        final Logger logger = Logger.getLogger(StopWatch.DEFAULT_LOGGER_NAME);
+        logger.addHandler(listHandler);
+        
+        ProfiledObject.simpleTestDefaultTagStatic(10);
+        assertTrue("Expected tag not found in "
+                        + listHandler.list.get(0).getMessage().toString(),
+                        listHandler.list.get(0).getMessage().toString()
+                        .indexOf("tag[simpleTestDefaultTagStatic]") >= 0);
+
+        new ProfiledObject().simpleTestUnprofiled(10);
+        assertTrue(
+                "Expected tag not found in "
+                        + listHandler.list.get(1).getMessage().toString(),
+                        listHandler.list.get(1).getMessage().toString()
+                        .indexOf("tag[simpleTestUnprofiled]") >= 0);
+
+        assertEquals("Expected two logging events", 2, listHandler.list.size());
+    }
+}

--- a/src/test/java/org/perf4j/javalog/aop/ListHandler.java
+++ b/src/test/java/org/perf4j/javalog/aop/ListHandler.java
@@ -1,0 +1,51 @@
+/* Copyright (c) 2011 Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.javalog.aop;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+/**
+ * 
+ * @author Brett Randall
+ * 
+ */
+public class ListHandler extends Handler {
+
+    public List<LogRecord> list;
+    
+    public ListHandler() {
+        list = new ArrayList<LogRecord>();
+    }
+    
+    @Override
+    public void publish(LogRecord record) {
+        list.add(record);
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() throws SecurityException {
+        list.clear();
+        list = null;
+    }
+
+}

--- a/src/test/java/org/perf4j/log4j/AopTest.java
+++ b/src/test/java/org/perf4j/log4j/AopTest.java
@@ -1,0 +1,56 @@
+/* Copyright (c) 2011 Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.log4j;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.xml.DOMConfigurator;
+import org.perf4j.StopWatch;
+import org.perf4j.aop.ProfiledObject;
+
+import junit.framework.TestCase;
+
+/**
+ * 
+ * @author Brett Randall
+ * 
+ */
+public class AopTest extends TestCase {
+
+    public void testAspects() throws Exception {
+
+        DOMConfigurator.configure(getClass().getResource("log4j.xml"));
+
+        final ListAppender listAppender = (ListAppender) Logger.getLogger(
+                StopWatch.DEFAULT_LOGGER_NAME).getAppender("listAppender");
+
+
+        ProfiledObject.simpleTestDefaultTagStatic(10);
+        assertTrue(
+                "Expected tag not found in "
+                        + listAppender.list.get(0).getMessage().toString(),
+                listAppender.list.get(0).getMessage().toString()
+                        .indexOf("tag[simpleTestDefaultTagStatic]") >= 0);
+
+        new ProfiledObject().simpleTestUnprofiled(10);
+        assertTrue(
+                "Expected tag not found in "
+                        + listAppender.list.get(1).getMessage().toString(),
+                listAppender.list.get(1).getMessage().toString()
+                        .indexOf("tag[simpleTestUnprofiled]") >= 0);
+
+        assertEquals("Expected two logging events", 2, listAppender.list.size());
+    }
+}

--- a/src/test/java/org/perf4j/log4j/ListAppender.java
+++ b/src/test/java/org/perf4j/log4j/ListAppender.java
@@ -1,0 +1,58 @@
+/* Copyright (c) 2011 Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.log4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.spi.LoggingEvent;
+
+/**
+ * Simple {@link Appender} which stored logging events in a {@link List}.
+ * Equivalent to same class in logback. Used for testing.
+ * 
+ * @author Brett Randall
+ * 
+ */
+public class ListAppender extends AppenderSkeleton {
+
+    public List<LoggingEvent> list;
+
+    public ListAppender() {
+        list = new ArrayList<LoggingEvent>();
+    }
+
+    @Override
+    protected void append(LoggingEvent loggingEvent) {
+        list.add(loggingEvent);
+    }
+
+    @Override
+    public boolean requiresLayout() {
+        return false;
+    }
+
+    @Override
+    public void close() {
+        if (list != null) {
+            list.clear();
+            list = null;
+        }
+    }
+
+}

--- a/src/test/java/org/perf4j/logback/AopTest.java
+++ b/src/test/java/org/perf4j/logback/AopTest.java
@@ -1,0 +1,67 @@
+/* Copyright (c) 2011 Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.logback;
+
+import org.perf4j.StopWatch;
+import org.perf4j.aop.ProfiledObject;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import junit.framework.TestCase;
+
+/**
+ * 
+ * @author Brett Randall
+ * 
+ */
+public class AopTest extends TestCase {
+
+    public void testAspects() throws Exception {
+
+        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(lc);
+
+        // the context was probably already configured by default configuration
+        // rules
+        lc.reset();
+
+        configurator.doConfigure(getClass().getResource("logback.xml"));
+
+        ListAppender<LoggingEvent> listAppender = (ListAppender<LoggingEvent>) lc
+                .getLogger(StopWatch.DEFAULT_LOGGER_NAME).getAppender(
+                        "listAppender");
+
+        ProfiledObject.simpleTestDefaultTagStatic(10);
+        assertTrue(
+                "Expected tag not found in "
+                        + listAppender.list.get(0).getMessage(),
+                listAppender.list.get(0).getMessage()
+                        .indexOf("tag[simpleTestDefaultTagStatic]") >= 0);
+
+        new ProfiledObject().simpleTestUnprofiled(10);
+        assertTrue(
+                "Expected tag not found in "
+                        + listAppender.list.get(1).getMessage(),
+                listAppender.list.get(1).getMessage()
+                        .indexOf("tag[simpleTestUnprofiled]") >= 0);
+
+        assertEquals("Expected two logging events", 2, listAppender.list.size());
+    }
+}

--- a/src/test/java/org/perf4j/logback/AppenderTest.java
+++ b/src/test/java/org/perf4j/logback/AppenderTest.java
@@ -42,9 +42,9 @@ public class AppenderTest extends TestCase {
         configurator.setContext(lc);
         // the context was probably already configured by default configuration 
         // rules
-        lc.reset(); 
+        lc.reset();
         configurator.doConfigure(getClass().getResource("logback.xml"));
-        
+
 
         AsyncCoalescingStatisticsAppender appender = (AsyncCoalescingStatisticsAppender) 
             lc.getLogger(StopWatch.DEFAULT_LOGGER_NAME).getAppender("coalescingStatistics");
@@ -67,7 +67,7 @@ public class AppenderTest extends TestCase {
         //tagName  avg           min     max     std dev       count, which is group 1
         String regex = "tag\\d\\s*\\d+\\.\\d\\s*\\d+\\s*\\d+\\s*\\d+\\.\\d\\s*(\\d+)";
         Pattern statLinePattern = Pattern.compile(regex);
-        Scanner scanner = new Scanner(new File("target/statisticsLog.log"));
+        Scanner scanner = new Scanner(new File("target/statisticsLogback.log"));
 
         int totalCount = 0;
         while (scanner.findWithinHorizon(statLinePattern, 0) != null) {
@@ -105,7 +105,7 @@ public class AppenderTest extends TestCase {
         configurator.setContext(lc);
         // the context was probably already configured by default configuration 
         // rules
-        lc.reset(); 
+        lc.reset();
         configurator.doConfigure(getClass().getResource("logbackWCsv.xml"));
 
         Logger logger = lc.getLogger("org.perf4j.CsvAppenderTest");
@@ -121,7 +121,7 @@ public class AppenderTest extends TestCase {
 
         //verify the statisticsLog.csv file
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        for (Object line : FileUtils.readLines(new File("./target/statisticsLog.csv"))) {
+        for (Object line : FileUtils.readLines(new File("./target/statisticsLogback.csv"))) {
             String[] values = line.toString().split(",");
             //first column is the tag
             assertEquals("\"csvTest\"", values[0]);

--- a/src/test/resources/META-INF/aop.xml
+++ b/src/test/resources/META-INF/aop.xml
@@ -9,5 +9,20 @@
 
     <aspects>
         <aspect name="org.perf4j.aop.InMemoryTimingAspect"/>
+        <aspect name="org.perf4j.slf4j.aop.TimingAspect"/>
+        <aspect name="org.perf4j.log4j.aop.TimingAspect"/>
+        <aspect name="org.perf4j.javalog.aop.TimingAspect"/>
+        <concrete-aspect name="org.perf4j.aop.__ScopedInMemoryTimingAspect" extends="org.perf4j.aop.ScopedInMemoryTimingAspect">
+            <pointcut name="scope" expression="execution(* simpleTestUnprofiled(..))"/>
+        </concrete-aspect>
+        <concrete-aspect name="org.perf4j.aop.__ScopedLogbackTimingAspect" extends="org.perf4j.slf4j.aop.ScopedTimingAspect">
+            <pointcut name="scope" expression="execution(* simpleTestUnprofiled(..))"/>
+        </concrete-aspect>
+        <concrete-aspect name="org.perf4j.aop.__ScopedLog4jTimingAspect" extends="org.perf4j.log4j.aop.ScopedTimingAspect">
+            <pointcut name="scope" expression="execution(* simpleTestUnprofiled(..))"/>
+        </concrete-aspect>
+        <concrete-aspect name="org.perf4j.aop.__ScopedJavalogTimingAspect" extends="org.perf4j.javalog.aop.ScopedTimingAspect">
+            <pointcut name="scope" expression="execution(* simpleTestUnprofiled(..))"/>
+        </concrete-aspect>
     </aspects>
 </aspectj>

--- a/src/test/resources/org/perf4j/log4j/log4j.xml
+++ b/src/test/resources/org/perf4j/log4j/log4j.xml
@@ -15,8 +15,11 @@
     </layout> 
   </appender>
 
+  <appender name="listAppender" class="org.perf4j.log4j.ListAppender" />
+
   <logger name="org.perf4j.TimingLogger">
     <level value="info"/>
     <appender-ref ref="coalescingStatistics"/>
+    <appender-ref ref="listAppender"/>
   </logger>
 </log4j:configuration>

--- a/src/test/resources/org/perf4j/logback/logback.xml
+++ b/src/test/resources/org/perf4j/logback/logback.xml
@@ -1,7 +1,7 @@
 <configuration debug="true">
 
   <appender name="statistics" class="ch.qos.logback.core.FileAppender">
-    <file>./target/statisticsLog.log</file>
+    <file>./target/statisticsLogBack.log</file>
     <append>false</append>
     <layout>
       <pattern>%msg%n</pattern>
@@ -15,7 +15,14 @@
 	<appender-ref ref="statistics"/>
   </appender>
     
+  <appender name="listAppender" class="ch.qos.logback.core.read.ListAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <timeSlice>1000</timeSlice>
+  </appender>
+  
   <logger name="org.perf4j.TimingLogger" level="info">
   	<appender-ref ref="coalescingStatistics" />
+    <appender-ref ref="listAppender"/>
   </logger>	
 </configuration>

--- a/src/test/resources/org/perf4j/logback/logbackWCsv.xml
+++ b/src/test/resources/org/perf4j/logback/logbackWCsv.xml
@@ -1,7 +1,7 @@
 <configuration debug="true">
 
   <appender name="statistics" class="ch.qos.logback.core.FileAppender">
-    <file>./target/statisticsLog.csv</file>
+    <file>./target/statisticsLogback.csv</file>
     <append>false</append>
     <layout class="org.perf4j.logback.StatisticsCsvLayout">
       <columns>tag,start,stop,mean,min,max,stddev,count,tps</columns>


### PR DESCRIPTION
Introduces new ScopedTimingAspect abstract AspectJ aspects, which can be
concretized with any simple pointcut expression in aop.xml, obviating the
need for explicit @Profiled annotations.

Incorporates PERFFORJ-62 so that tests pass.
