### PR TITLE
PERFFORJ-56 : Configurable default logging tag and message

### DIFF
--- a/src/main/java/org/perf4j/helpers/PackageParentProperties.java
+++ b/src/main/java/org/perf4j/helpers/PackageParentProperties.java
@@ -1,0 +1,65 @@
+/* Copyright (c) 2011 Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.helpers;
+
+import java.util.Properties;
+
+public class PackageParentProperties extends Properties {
+
+    private static final long serialVersionUID = 4732002255463533934L;
+
+
+    public PackageParentProperties() {
+        super();
+    }
+
+    public PackageParentProperties(Properties defaults) {
+        super(defaults);
+    }
+
+    @Override
+    public synchronized Object get(Object key) {
+
+        if (key == null) {
+            throw new NullPointerException();
+        }
+
+        if (!(key instanceof String)) {
+            return super.get(key);
+        }
+
+        String keyString = (String) key;
+
+        Object o = super.get(keyString);
+        if (o != null) {
+            // found at current position
+            return o;
+        }
+
+        // search parent if exists
+        if (keyString.contains(".")) {
+            // com.some.package.SomeClass -> com.some.package
+            // com.some.package -> com.some
+            // com.some -> com
+            keyString = keyString.substring(0, keyString.lastIndexOf('.'));
+            return get(keyString);
+        } else {
+            // all parent keys exhausted, look no further
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/org/perf4j/helpers/Perf4jProperties.java
+++ b/src/main/java/org/perf4j/helpers/Perf4jProperties.java
@@ -1,0 +1,50 @@
+/* Copyright (c) 2011 Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.helpers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class Perf4jProperties {
+
+    public static final Properties INSTANCE;
+
+    static {
+        INSTANCE = new PackageParentProperties();
+        final InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream("perf4j.properties");
+        if (is != null) {
+            try {
+                INSTANCE.load(is);
+            } catch (IOException e) {
+                System.err.println("Failed to load perf4j.properties");
+            } finally {
+                if (is != null) {
+                    try {
+                        is.close();
+                    } catch (IOException e) {
+                        // TODO Auto-generated catch block
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+    }
+
+    private Perf4jProperties() {
+        // singleton, not instantiable externally
+    }
+}

--- a/src/test/java/org/perf4j/aop/AopTest.java
+++ b/src/test/java/org/perf4j/aop/AopTest.java
@@ -119,6 +119,19 @@ public class AopTest extends TestCase {
                    InMemoryTimingAspect.getLastLoggedString().indexOf("expressionTest_null]") >= 0);
         assertTrue("Expected message not found in " + InMemoryTimingAspect.getLastLoggedString(),
                    InMemoryTimingAspect.getLastLoggedString().indexOf("message[message: 5, exception: java.lang.Exception: failure]") >= 0);
+
+        profiledObject.simpleTestDefaultTagMessageFromProperties(5);
+        assertTrue("Expected tag not found in " + InMemoryTimingAspect.getLastLoggedString(),
+                InMemoryTimingAspect.getLastLoggedString().indexOf("tag[customTag]") >= 0);
+        assertTrue("Expected tag not found in " + InMemoryTimingAspect.getLastLoggedString(),
+                InMemoryTimingAspect.getLastLoggedString().indexOf("message[customMessage]") >= 0);
+
+        profiledObject.simpleTestDefaultTagMessageFromPropertiesJexl(5);
+        assertTrue("Expected tag not found in " + InMemoryTimingAspect.getLastLoggedString(),
+                InMemoryTimingAspect.getLastLoggedString().indexOf("tag[org.perf4j.aop.ProfiledObject#simpleTestDefaultTagMessageFromPropertiesJexl]") >= 0);
+        assertTrue("Expected tag not found in " + InMemoryTimingAspect.getLastLoggedString(),
+                InMemoryTimingAspect.getLastLoggedString().indexOf("message[simpleTestDefaultTagMessageFromPropertiesJexl(5)]") >= 0);
+
     }
 
     public void testConcurrentCalls() throws Exception {

--- a/src/test/java/org/perf4j/aop/ProfiledObject.java
+++ b/src/test/java/org/perf4j/aop/ProfiledObject.java
@@ -30,7 +30,31 @@ public class ProfiledObject {
         Thread.sleep(sleepTime);
         return sleepTime;
     }
-    
+
+    /**
+     * See perf4j.properties for expected tag and message
+     * @param sleepTime
+     * @return
+     * @throws Exception
+     */
+    @Profiled
+    public long simpleTestDefaultTagMessageFromProperties(long sleepTime) throws Exception {
+        Thread.sleep(sleepTime);
+        return sleepTime;
+    }
+
+    /**
+     * See perf4j.properties for expected tag and message
+     * @param sleepTime
+     * @return
+     * @throws Exception
+     */
+    @Profiled
+    public long simpleTestDefaultTagMessageFromPropertiesJexl(long sleepTime) throws Exception {
+        Thread.sleep(sleepTime);
+        return sleepTime;
+    }
+
     @Profiled(tag = "simple")
     public long simpleTest(long sleepTime) throws Exception {
         Thread.sleep(sleepTime);

--- a/src/test/java/org/perf4j/helpers/PackageParentPropertiesTest.java
+++ b/src/test/java/org/perf4j/helpers/PackageParentPropertiesTest.java
@@ -1,0 +1,47 @@
+/* Copyright (c) 2011 Brett Randall.
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.helpers;
+
+import java.util.Properties;
+
+import junit.framework.TestCase;
+
+public class PackageParentPropertiesTest extends TestCase {
+
+    // this actually loads a PackageParentProperties singleton
+    final Properties properties = Perf4jProperties.INSTANCE;
+
+    public void testFullPath() {
+        assertEquals("some tag", properties.get("tag." + getClass().getName()));
+        assertEquals("some message", properties.get("message." + getClass().getName()));
+    }
+
+    public void testParentPath() {
+        assertEquals("parent tag", properties.get("tag.org.perf4j.helpers.ClassNotInProperties"));
+        assertEquals("parent message", properties.get("message.org.perf4j.helpers.ClassNotInProperties"));
+    }
+
+    public void testAncestorPath() {
+        assertEquals("ancestor tag", properties.get("tag.org.perf4j"));
+        assertEquals("ancestor message", properties.get("message.org.perf4j"));
+    }
+
+
+    public void testDefaultPath() {
+        assertEquals("default tag", properties.get("tag.no.common.path.MyClass"));
+        assertEquals("default message", properties.get("message.no.common.path.MyClass"));
+    }
+}

--- a/src/test/resources/perf4j.properties
+++ b/src/test/resources/perf4j.properties
@@ -1,0 +1,17 @@
+tag=default tag
+message=default message
+
+tag.org.perf4j.helpers.PackageParentPropertiesTest=some tag
+message.org.perf4j.helpers.PackageParentPropertiesTest=some message
+
+tag.org.perf4j.helpers=parent tag
+message.org.perf4j.helpers=parent message
+
+tag.org.perf4j=ancestor tag
+message.org.perf4j=ancestor message
+
+tag.org.perf4j.aop.ProfiledObject.simpleTestDefaultTagMessageFromProperties=customTag
+message.org.perf4j.aop.ProfiledObject.simpleTestDefaultTagMessageFromProperties=customMessage
+
+tag.org.perf4j.aop.ProfiledObject.simpleTestDefaultTagMessageFromPropertiesJexl={$class.name}#{$methodName}
+message.org.perf4j.aop.ProfiledObject.simpleTestDefaultTagMessageFromPropertiesJexl={$methodName}({$0})


### PR DESCRIPTION
https://jira.codehaus.org/browse/PERFFORJ-56

A properties file perf4j.properties is now loaded from the classpath if it
exists and will format AOP tags and messages where not specified on an
@Profiled annotation.  Entries in this file are:

tag.com.package.ClassName.methodName=static tag
message.com.package.ClassName.methodName=static message

tag.com.package.AllMethodsInClass=static tag

tag.com.parent.package.inherited=static tag

tag.com.package.ClassName.methodName={$class.name}#{$methodName}
message.com.package.ClassName.methodName={$methodName}({$0})
