### PR TITLE
JSON LogParser output format

### DIFF
--- a/src/main/java/org/perf4j/GroupedTimingStatistics.java
+++ b/src/main/java/org/perf4j/GroupedTimingStatistics.java
@@ -15,10 +15,10 @@
  */
 package org.perf4j;
 
-import org.perf4j.helpers.MiscUtils;
-
 import java.io.Serializable;
 import java.util.*;
+
+import org.perf4j.helpers.MiscUtils;
 
 /**
  * Represents a set of TimingStatistics calculated for a specific time period for a set of tags.
@@ -100,7 +100,16 @@ public class GroupedTimingStatistics implements Serializable, Cloneable {
 
         return this;
     }
-
+    
+    /**
+     * The length of time, in milliseconds, of the data window
+     *  
+     * @return length of time, in milliseconds, of the data window
+     */
+    public long getWindowLength() {
+        return stopTime - startTime;
+    }
+    
     /**
      * The TimeZone to use when displaying start/stop time information
      */
@@ -170,7 +179,8 @@ public class GroupedTimingStatistics implements Serializable, Cloneable {
 
     // --- Object Methods ---
 
-    public String toString() {
+    @Override
+	public String toString() {
         StringBuilder retVal = new StringBuilder();
         
         int paddingToAllowForLongestTag = Math.max(getLongestTag(statisticsByTag.keySet()), "Tag".length());
@@ -214,7 +224,8 @@ public class GroupedTimingStatistics implements Serializable, Cloneable {
         return longestLength;
     }
 
-    public GroupedTimingStatistics clone() {
+    @Override
+	public GroupedTimingStatistics clone() {
         try {
             GroupedTimingStatistics retVal = (GroupedTimingStatistics) super.clone();
             retVal.statisticsByTag = new TreeMap<String, TimingStatistics>(retVal.statisticsByTag);
@@ -227,7 +238,8 @@ public class GroupedTimingStatistics implements Serializable, Cloneable {
         }
     }
 
-    public boolean equals(Object o) {
+    @Override
+	public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
@@ -242,7 +254,8 @@ public class GroupedTimingStatistics implements Serializable, Cloneable {
                statisticsByTag.equals(that.statisticsByTag);
     }
 
-    public int hashCode() {
+    @Override
+	public int hashCode() {
         int result;
         result = statisticsByTag.hashCode();
         result = 31 * result + (int) (startTime ^ (startTime >>> 32));

--- a/src/main/java/org/perf4j/LogParser.java
+++ b/src/main/java/org/perf4j/LogParser.java
@@ -15,15 +15,15 @@
  */
 package org.perf4j;
 
-import org.perf4j.helpers.*;
-import org.perf4j.chart.StatisticsChartGenerator;
-import org.perf4j.chart.GoogleChartGenerator;
-
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+
+import org.perf4j.helpers.*;
+import org.perf4j.chart.GoogleChartGenerator;
+import org.perf4j.chart.StatisticsChartGenerator;
 
 /**
  * LogParser provides the main method for reading a log of StopWatch output and generating statistics and graphs
@@ -64,7 +64,7 @@ public class LogParser {
     /**
      * The formatter to use to print statistics.
      */
-    private GroupedTimingStatisticsFormatter statisticsFormatter;
+    private StatisticsFormatter statisticsFormatter;
 
     // --- Constructors ---
     /**
@@ -77,7 +77,7 @@ public class LogParser {
              null /* no graph output */,
              30000L,
              false /* don't create rollup statistics */,
-             new GroupedTimingStatisticsTextFormatter());
+             new DefaultStatisticsFormatter(new GroupedTimingStatisticsTextFormatter()));
     }
 
     /**
@@ -93,7 +93,7 @@ public class LogParser {
      */
     public LogParser(Reader inputLog, PrintStream statisticsOutput, PrintStream graphingOutput,
                      long timeSlice, boolean createRollupStatistics,
-                     GroupedTimingStatisticsFormatter statisticsFormatter) {
+                     StatisticsFormatter statisticsFormatter) {
         this.inputLog = inputLog;
         this.statisticsOutput = statisticsOutput;
         this.graphingOutput = graphingOutput;
@@ -113,6 +113,10 @@ public class LogParser {
      * to the output streams.
      */
     public void parseLog() {
+    	
+    	if (statisticsOutput != null) {
+            statisticsOutput.print(statisticsFormatter.header());
+        }
 
         Iterator<StopWatch> stopWatchIter = new StopWatchLogIterator(inputLog);
 
@@ -136,6 +140,10 @@ public class LogParser {
                 }
             }
         }
+        
+        if (statisticsOutput != null) {
+            statisticsOutput.print(statisticsFormatter.footer());
+        }
     }
 
     protected StatisticsChartGenerator newMeanTimeChartGenerator() {
@@ -158,28 +166,34 @@ public class LogParser {
     }
 
     public static int runMain(String[] args) {
-        try {
+    	try {
             List<String> argsList = new ArrayList<String>(Arrays.asList(args));
 
             if (printUsage(argsList)) {
                 return 0;
             }
-
-            PrintStream statisticsOutput = openStatisticsOutput(argsList);
-            PrintStream graphingOutput = openGraphingOutput(argsList);
-            long timeSlice = getTimeSlice(argsList);
-            boolean rollupStatistics = getRollupStatistics(argsList);
-            GroupedTimingStatisticsFormatter formatter = getStatisticsFormatter(argsList);
-            Reader input = openInput(argsList);
-
-            if (!argsList.isEmpty()) {
-                printUnknownArgs(argsList);
-                return 1;
-            }
-
-            new LogParser(input, statisticsOutput, graphingOutput, timeSlice, rollupStatistics, formatter).parseLog();
-
-            closeGraphingOutput(graphingOutput);
+            PrintStream statisticsOutput = null;
+        	PrintStream graphingOutput = null;
+        	Reader input = null;
+        	try {
+	            long timeSlice = getTimeSlice(argsList);
+	            boolean rollupStatistics = getRollupStatistics(argsList);
+	            StatisticsFormatter formatter = getStatisticsFormatter(argsList);
+	            statisticsOutput = openStatisticsOutput(argsList);
+	            graphingOutput = openGraphingOutput(argsList);
+	            input = openInput(argsList);
+	
+	            if (!argsList.isEmpty()) {
+	                printUnknownArgs(argsList);
+	                return 1;
+	            }
+	
+	            new LogParser(input, statisticsOutput, graphingOutput, timeSlice, rollupStatistics, formatter).parseLog();
+        	} finally {
+        		closeInput(input);
+        		closeStatisticsOutput(statisticsOutput);
+        		closeGraphingOutput(graphingOutput);
+        	}
         } catch ( Exception e ) {
             e.printStackTrace();
             return 1;
@@ -242,6 +256,23 @@ public class LogParser {
             return null;
         }
     }
+    
+    protected static void closeInput(Reader input) throws IOException {
+        if (input != null) {
+        	// InputStreamReader is used for stdin
+            if (!(input instanceof InputStreamReader)) {
+            	input.close();
+            }
+        }
+    }
+    
+    protected static void closeStatisticsOutput(PrintStream statisticsOutput) throws IOException {
+        if (statisticsOutput != null) {
+            if (statisticsOutput != System.out && statisticsOutput != System.err) {
+            	statisticsOutput.close();
+            }
+        }
+    }
 
     protected static void closeGraphingOutput(PrintStream graphingOutput) throws IOException {
         if (graphingOutput != null) {
@@ -273,20 +304,22 @@ public class LogParser {
         }
     }
 
-    protected static GroupedTimingStatisticsFormatter getStatisticsFormatter(List<String> argsList) {
+    protected static StatisticsFormatter getStatisticsFormatter(List<String> argsList) {
         int indexOfFormat = getIndexOfArg(argsList, true, "-f", "--format");
         if (indexOfFormat >= 0) {
             String formatString = argsList.remove(indexOfFormat + 1);
             argsList.remove(indexOfFormat);
             if ("text".equalsIgnoreCase(formatString)) {
-                return new GroupedTimingStatisticsTextFormatter();
+                return new DefaultStatisticsFormatter(new GroupedTimingStatisticsTextFormatter());
             } else if ("csv".equalsIgnoreCase(formatString)) {
-                return new GroupedTimingStatisticsCsvFormatter();
+                return new DefaultStatisticsFormatter(new GroupedTimingStatisticsCsvFormatter());
+            } else if (formatString.startsWith("json")) {
+                return new GroupedTimingStatisticsJsonFormatter(formatString);
             } else {
                 throw new IllegalArgumentException("Unknown format type: " + formatString);
             }
         } else {
-            return new GroupedTimingStatisticsTextFormatter();
+            return new DefaultStatisticsFormatter(new GroupedTimingStatisticsTextFormatter());
         }
     }
 

--- a/src/main/java/org/perf4j/chart/GoogleChartGenerator.java
+++ b/src/main/java/org/perf4j/chart/GoogleChartGenerator.java
@@ -15,16 +15,16 @@
  */
 package org.perf4j.chart;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
 import org.perf4j.GroupedTimingStatistics;
 import org.perf4j.TimingStatistics;
 import org.perf4j.helpers.StatsValueRetriever;
-
-import java.util.*;
-import java.net.URLEncoder;
-import java.io.UnsupportedEncodingException;
-import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
-import java.text.DecimalFormatSymbols;
 
 /**
  * This implementation of StatisticsChartGenerator creates a chart URL in the format expected by the Google Chart API.
@@ -248,7 +248,7 @@ public class GoogleChartGenerator implements StatisticsChartGenerator {
         for (GroupedTimingStatistics groupedTimingStatistics : data) {
             Map<String, TimingStatistics> statsByTag = groupedTimingStatistics.getStatisticsByTag();
             long windowStartTime = groupedTimingStatistics.getStartTime();
-            long windowLength = groupedTimingStatistics.getStopTime() - windowStartTime;
+            long windowLength = groupedTimingStatistics.getWindowLength();
             //keep track of the min/max time value, this is needed for scaling the chart parameters
             minTimeValue = Math.min(minTimeValue, windowStartTime);
             maxTimeValue = Math.max(maxTimeValue, windowStartTime);

--- a/src/main/java/org/perf4j/helpers/DefaultStatisticsFormatter.java
+++ b/src/main/java/org/perf4j/helpers/DefaultStatisticsFormatter.java
@@ -1,0 +1,57 @@
+/* Copyright (c) 2012
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.helpers;
+
+import org.perf4j.GroupedTimingStatistics;
+
+/**
+ * Default {@link StatisticsFormatter} that has no header or footer and delegates
+ * all formatting to a {@link GroupedTimingStatisticsFormatter}.
+ * 
+ * @see GroupedTimingStatisticsFormatter
+ * @author Kyle Cronin
+ */
+public class DefaultStatisticsFormatter implements StatisticsFormatter {
+	
+	private final GroupedTimingStatisticsFormatter formatter;
+	
+	// --- Constructors ---
+	
+	/**
+	 * Construct new formatter that delegates formatting to the specified 
+	 * {@link GroupedTimingStatisticsFormatter}
+	 * 
+	 * @param formatter grouped timing statistics formatter to delegate formatting to
+	 */
+	public DefaultStatisticsFormatter(GroupedTimingStatisticsFormatter formatter) {
+		this.formatter = formatter;
+	}
+
+	// --- Object Methods ---
+	
+	public String format(GroupedTimingStatistics stats) {
+		return formatter.format(stats);
+	}
+
+	public String header() {
+		return "";
+	}
+
+	public String footer() {
+		return "";
+	}
+
+}

--- a/src/main/java/org/perf4j/helpers/GroupedTimingStatisticsJsonFormatter.java
+++ b/src/main/java/org/perf4j/helpers/GroupedTimingStatisticsJsonFormatter.java
@@ -1,0 +1,319 @@
+/* Copyright (c) 2012
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.helpers;
+
+import java.util.Map;
+
+import org.perf4j.GroupedTimingStatistics;
+import org.perf4j.TimingStatistics;
+
+/**
+ * This helper formatter class outputs {@link org.perf4j.GroupedTimingStatistics} in a JSON value format. This
+ * formatter supports the following JSON formats:
+ * <ul>
+ * 	<li> json - Alias for {@code json:list}
+ *  <li> json:list - formatted as an array of arrays and the most compact format
+ *  <li> json:list-objects - formatted as an array of objects with timing properties
+ * 	<li> json:google-datatable - formatted as a Google DataTable data object (See <a href="https://developers.google.com/chart/interactive/docs/reference#DataTable">DataTable</a>)
+ * </ul>
+ * 
+ * <h6>List Format</h6>
+ * Index Value:
+ * <ul>
+ * 	<li>0 = Tag name
+ * 	<li>1 = Start Time
+ * 	<li>2 = Stop Time
+ * 	<li>3 = Mean
+ * 	<li>4 = Min
+ * 	<li>5 = Max
+ * 	<li>6 = Standard Deviation
+ * 	<li>7 = Count
+ * 	<li>8 = Transaction Per Second
+ * </ul>
+ * <pre>
+ * [["tag",new Date(0000000),new Date(0000000), 0, 0, 0, 0, 0, 0], ...]
+ * </pre>
+ * This format can be converted to a Google <a href="https://developers.google.com/chart/interactive/docs/reference#DataTable">DataTable</a> using the helper function 
+ * <code><a href="https://developers.google.com/chart/interactive/docs/reference#google.visualization.arraytodatatable">google.visualization.arrayToDataTable()</a></code>
+
+ * <h6>List-Objects Format</h6>
+ * <pre>
+ * [{tag:"name",startTime:new Date(0000000),stopTime:new Date(0000000),mean:0,min:0.max:0,stddev:0,count:0,tps:0}, ...]
+ * </pre>
+ * 
+ * <h6>Google DataTable Format</h6>
+ * Google DataTable format is designed for use with Google Visualization API.
+ * See <a href="https://developers.google.com/chart/interactive/docs/reference#DataTable">DataTable</a> documentation
+ * and <a href="https://developers.google.com/chart/interactive/docs/index">Google Chart Tools</a>.
+ * <pre>
+ * {
+ * cols: [{id: 'tab', label: 'Tag', type: 'string'},
+ *        {id: 'startTime', label: 'Start Time', type: 'date'}
+ *        {id: 'stopTime', label: 'Stop Time', type: 'date'}
+ *        {id: 'mean', label: 'Mean', type: 'number'},
+ *        {id: 'min', label: 'Min', type: 'number'},
+ *        {id: 'max', label: 'Max', type: 'number'},
+ *        {id: 'stddev', label: 'Standard Deviation', type: 'number'},
+ *        {id: 'count', label: 'Count', type: 'number'},
+ *        {id: 'tps', label: 'Transactions Per Second', type: 'number'}
+ *       ],
+ * rows: [{c:[{v: 'tag'}, {v: new Date(0000000)},{v: new Date(0000000)},{v: 0},{v: 0},{v: 0},{v: 0},{v: 0},{v: 0}]}
+ *      ]
+ * }
+ * </pre>
+ * 
+ * @author Kyle Cronin
+ */
+public class GroupedTimingStatisticsJsonFormatter implements StatisticsFormatter, GroupedTimingStatisticsFormatter {
+
+	private enum JsonFormat {
+		GOOGLE_DATA_TABLE("google-datatable"),
+		LIST("list"),
+		LIST_OBJECTS("list-objects");;
+
+		String id;
+		private JsonFormat(String id) {
+			this.id = id; 
+		}
+
+		public static JsonFormat findById(String id) {
+			for (JsonFormat format : JsonFormat.values()) {
+				if(format.id.equalsIgnoreCase(id)) {
+					return format;
+				}
+			}
+			return null;
+		}
+	}
+
+	private final JsonFormat format;
+	private boolean isFirst = true;
+	
+	 // --- Constructors ---
+	
+	/**
+	 * Construct {@link JsonFormat#LIST} formatter 
+	 */
+	public GroupedTimingStatisticsJsonFormatter() {
+		this.format = JsonFormat.LIST;
+	}
+
+	/**
+	 * Construct JSON formatter
+	 * @see JsonFormat
+	 * @param jsonFormat json format type, not {@code null}
+	 * @throws IllegalArgumentException if {@code jsonFormat} is not one of the supported format types
+	 */
+	public GroupedTimingStatisticsJsonFormatter(String jsonFormat) {
+		String[] parts = jsonFormat.split(":");
+		String formatId = JsonFormat.LIST.id;
+		switch (parts.length) {
+		case 2:
+			formatId = parts[1];
+			break;
+		}
+		this.format = JsonFormat.findById(formatId);
+		if(this.format == null) {
+			throw new IllegalArgumentException("Unknown json format " + formatId);
+		}
+	}
+	
+	// --- Formatting Methods ---
+
+	public String format(GroupedTimingStatistics stats) {
+		switch (format) {
+		case GOOGLE_DATA_TABLE:
+			return formatGoogleDataTableRow(stats);
+		case LIST_OBJECTS:
+			formatListObjects(stats);
+		default:
+			return formatList(stats);
+		}
+	}
+
+	/**
+	 * Format statistics as Google DataTable row
+	 * 
+	 * @see https://developers.google.com/chart/interactive/docs/reference#DataTable
+	 * @param stats timing statistics
+	 * @return formatted statistics string
+	 */
+	private String formatGoogleDataTableRow(GroupedTimingStatistics stats) {
+		StringBuilder retVal = new StringBuilder();
+		for (Map.Entry<String, TimingStatistics> tagAndStats : stats.getStatisticsByTag().entrySet()) {
+			if(!isFirst) {
+				retVal.append(",").append(MiscUtils.NEWLINE);
+			} else {
+				isFirst = false;
+			}
+			String tag = tagAndStats.getKey();
+			TimingStatistics timingStats = tagAndStats.getValue();
+			retVal.append("{c:[");
+			retVal.append("{v:'").append(jsonize(tag)).append("'},");
+			retVal.append("{v:new Date(").append(stats.getStartTime()).append(")},");
+			retVal.append("{v:new Date(").append(stats.getStopTime()).append(")},");
+			retVal.append("{v: ").append(timingStats.getMean()).append("},");
+			retVal.append("{v:").append(timingStats.getMin()).append("},");
+			retVal.append("{v:").append(timingStats.getMax()).append("},");
+			retVal.append("{v:").append(timingStats.getStandardDeviation()).append("},");
+			retVal.append("{v:").append(timingStats.getCount()).append("},");
+			retVal.append("{v:").append(StatsValueRetriever.TPS_VALUE_RETRIEVER.getStatsValue(timingStats, stats.getWindowLength())).append("}");
+			retVal.append("]}");
+		}
+		return retVal.toString();
+	}
+
+	/**
+	 * Format statistics as JSON object
+	 * @param stats timing statistics
+	 * @return formatted statistics string
+	 */
+	private String formatListObjects(GroupedTimingStatistics stats) {
+		StringBuilder retVal = new StringBuilder();
+		for (Map.Entry<String, TimingStatistics> tagAndStats : stats.getStatisticsByTag().entrySet()) {
+			if(!isFirst) {
+				retVal.append(",").append(MiscUtils.NEWLINE);
+			} else {
+				isFirst = false;
+			}
+			String tag = tagAndStats.getKey();
+			TimingStatistics timingStats = tagAndStats.getValue();
+			retVal.append("{tag:'").append(jsonize(tag)).append("',");
+			retVal.append("startTime:new Date(").append(stats.getStartTime()).append("),");
+			retVal.append("stopTime:new Date(").append(stats.getStopTime()).append("),");
+			retVal.append("mean:").append(timingStats.getMean()).append(",");
+			retVal.append("min:").append(timingStats.getMin()).append(",");
+			retVal.append("max:").append(timingStats.getMax()).append(",");
+			retVal.append("stddev:").append(timingStats.getStandardDeviation()).append(",");
+			retVal.append("count:").append(timingStats.getCount()).append(",");
+			retVal.append("tps:").append(StatsValueRetriever.TPS_VALUE_RETRIEVER.getStatsValue(timingStats, stats.getWindowLength()));
+			retVal.append("}");
+		}
+		return retVal.toString();
+	}
+	
+	/**
+	 * Format statistics as JSON array
+	 * @param stats timing statistics
+	 * @return formatted statistics string
+	 */
+	private String formatList(GroupedTimingStatistics stats) {
+		StringBuilder retVal = new StringBuilder();
+		for (Map.Entry<String, TimingStatistics> tagAndStats : stats.getStatisticsByTag().entrySet()) {
+			if(!isFirst) {
+				retVal.append(",").append(MiscUtils.NEWLINE);
+			} else {
+				isFirst = false;
+			}
+			String tag = tagAndStats.getKey();
+			TimingStatistics timingStats = tagAndStats.getValue();
+			retVal.append("['").append(jsonize(tag)).append("',");
+			retVal.append("new Date(").append(stats.getStartTime()).append("),");
+			retVal.append("new Date(").append(stats.getStopTime()).append("),");
+			retVal.append(timingStats.getMean()).append(",");
+			retVal.append(timingStats.getMin()).append(",");
+			retVal.append(timingStats.getMax()).append(",");
+			retVal.append(timingStats.getStandardDeviation()).append(",");
+			retVal.append(timingStats.getCount()).append(",");
+			retVal.append(StatsValueRetriever.TPS_VALUE_RETRIEVER.getStatsValue(timingStats, stats.getWindowLength()));
+			retVal.append("]");
+		}
+		return retVal.toString();
+	}
+
+	public String header() {
+		isFirst = true;
+		StringBuilder retVal = new StringBuilder();
+		switch (format) {
+		case GOOGLE_DATA_TABLE:
+			retVal.append("{").append(MiscUtils.NEWLINE);
+			retVal.append("cols:[{id: 'tag', label:'Tag', type: 'string'},").append(MiscUtils.NEWLINE);
+			retVal.append("{id: 'startTime', label:'Start Time', type: 'datetime'},").append(MiscUtils.NEWLINE);
+			retVal.append("{id: 'stopTime', label:'Stop Time', type: 'datetime'},").append(MiscUtils.NEWLINE);
+			retVal.append("{id: 'mean', label:'Mean', type: 'number'},").append(MiscUtils.NEWLINE);
+			retVal.append("{id: 'min', label:'Min', type: 'number'},").append(MiscUtils.NEWLINE);
+			retVal.append("{id: 'max', label:'Max', type: 'number'},").append(MiscUtils.NEWLINE);
+			retVal.append("{id: 'stddev', label:'Standard Deviation', type: 'number'},").append(MiscUtils.NEWLINE);
+			retVal.append("{id: 'count', label:'Count', type: 'number'},").append(MiscUtils.NEWLINE);
+			retVal.append("{id: 'tps', label:'Transactions Per Second', type: 'number'}],").append(MiscUtils.NEWLINE);
+			retVal.append("rows: [").append(MiscUtils.NEWLINE);
+			break;
+		default:
+			retVal.append("[");
+			break;
+		}
+		return retVal.toString();
+	}
+
+	public String footer() {
+		isFirst = true;
+		switch (format) {
+		case GOOGLE_DATA_TABLE:
+			return "]}";
+		default:
+			return "]";
+		}
+	}
+	
+	// --- Helper Methods ---
+	
+	/**
+	 * JSONize a string value, performing any character escaping as needed.
+	 * @param value string value, or {@code null}
+	 * @return jsonized string value or {@code null} if input value was {@code null}
+	 */
+	private static String jsonize(String value) {
+		if (value == null) {
+			return null;
+		}
+
+		// Start with a buffer the size of the input string + a little to avoid
+		// resizing for most strings.
+		StringBuilder builder = new StringBuilder(value.length() + 5);
+		int length = value.length();
+		int i = 0;
+		while (i < length) {
+			char c = value.charAt(i++);
+			switch (c) {
+			case '"':
+				builder.append("\\\"");
+				break;
+			case '\'':
+				builder.append("\\\'");
+				break;
+			case '\\':
+				builder.append("\\\\");
+				break;
+			case '\n':
+				builder.append("\\\n");
+				break;
+			case '\r':
+				builder.append("\\\r");
+				break;
+			case '\b':
+				builder.append("\\\b");
+				break;
+			case '\f':
+				builder.append("\\\f");
+				break;
+			default:
+				builder.append(c);
+			}
+		}
+
+		return builder.toString();
+	}
+}

--- a/src/main/java/org/perf4j/helpers/StatisticsExposingMBean.java
+++ b/src/main/java/org/perf4j/helpers/StatisticsExposingMBean.java
@@ -195,7 +195,7 @@ public class StatisticsExposingMBean extends NotificationBroadcasterSupport impl
             String statisticName = matcher.group(2);
 
             TimingStatistics timingStats = currentTimingStatistics.getStatisticsByTag().get(tagName);
-            long windowLength = currentTimingStatistics.getStopTime() - currentTimingStatistics.getStartTime();
+            long windowLength = currentTimingStatistics.getWindowLength();
 
             return getStatsValueRetrievers().get(statisticName).getStatsValue(timingStats, windowLength);
         } else {
@@ -242,7 +242,8 @@ public class StatisticsExposingMBean extends NotificationBroadcasterSupport impl
         return managementInterface;
     }
 
-    public MBeanNotificationInfo[] getNotificationInfo() {
+    @Override
+	public MBeanNotificationInfo[] getNotificationInfo() {
         return managementInterface.getNotifications();
     }
 

--- a/src/main/java/org/perf4j/helpers/StatisticsFormatter.java
+++ b/src/main/java/org/perf4j/helpers/StatisticsFormatter.java
@@ -1,0 +1,35 @@
+/* Copyright (c) 2012
+ * All rights reserved.  http://www.perf4j.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.perf4j.helpers;
+
+/**
+ * Statistics output formatter
+ * 
+ * @author Kyle Cronin
+ */
+public interface StatisticsFormatter extends GroupedTimingStatisticsFormatter {
+    /**
+     * Header text
+     * @return header text
+     */
+    String header();
+    
+    /**
+     * Footer text
+     * @return footer text
+     */
+    String footer();
+}


### PR DESCRIPTION
Added support for JSON output format which is useful for including generated statistics in custom charts and reports.

```
java -jar perf4j.jar -f json times.json
java -jar perf4j.jar -f json:google-datatable times.gdata
java -jar perf4j.jar -f json:list-objects times.json
```
